### PR TITLE
Extend confirmation rule to blocks from the previous epoch

### DIFF
--- a/fork_choice/confirmation-rule.md
+++ b/fork_choice/confirmation-rule.md
@@ -82,7 +82,7 @@ def get_committee_weight_between_slots(state: BeaconState, start_slot: Slot, end
     committee_weight = total_active_balance // SLOTS_PER_EPOCH
     
     if start_epoch == end_epoch:
-        return (end_slot - start_slot + 1) * committee_weight
+        return Gwei((end_slot - start_slot + 1) * committee_weight)
     else:
         # A range that spans an epoch boundary, but does not span any full epoch
         # needs pro-rata calculation

--- a/fork_choice/confirmation-rule.md
+++ b/fork_choice/confirmation-rule.md
@@ -18,6 +18,7 @@
     - [`get_ffg_support`](#get_ffg_support)
     - [`is_ffg_confirmed_current_epoch`](#is_ffg_confirmed_current_epoch)
     - [`is_ffg_confirmed_previous_epoch`](#is_ffg_confirmed_previous_epoch)
+    - [`is_ffg_confirmed`](#is_ffg_confirmed)
   - [`is_confirmed`](#is_confirmed)
 - [Safe Block Hash](#safe-block-hash)
   - [Helper Functions](#helper-functions-1)
@@ -29,6 +30,7 @@
     - [`get_lmd_confirmation_score`](#get_lmd_confirmation_score)
     - [`get_ffg_confirmation_score_current_epoch`](#get_ffg_confirmation_score_current_epoch)
     - [`get_ffg_confirmation_score_previous_epoch`](#get_ffg_confirmation_score_previous_epoch)
+    - [`get_ffg_confirmation_score`](#get_ffg_confirmation_score)
   - [`get_confirmation_score`](#get_confirmation_score)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/tests/core/pyspec/eth2spec/test/bellatrix/confirmation_rule/test_confirmation_rule.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/confirmation_rule/test_confirmation_rule.py
@@ -1,0 +1,668 @@
+
+from eth2spec.test.context import (
+    spec_state_test,
+    with_presets,
+    with_all_phases
+)
+from eth2spec.test.helpers.attestations import get_valid_attestation_at_slot, next_epoch_with_attestations, next_slots_with_attestations
+from eth2spec.test.helpers.constants import MINIMAL
+from eth2spec.test.helpers.fork_choice import (
+    add_block,
+    get_genesis_forkchoice_store_and_block,
+)
+
+from eth2spec.test.helpers.state import (
+    next_epoch,
+)
+
+def on_tick_step(spec, store, time, test_steps):
+    spec.on_tick(store, time)
+    test_steps.append({'tick': int(time)})
+    
+def tick_to_next_slot(spec, store, test_steps):
+        time = store.genesis_time + (spec.get_current_slot(store) + 1) * spec.config.SECONDS_PER_SLOT
+        on_tick_step(spec, store, time, test_steps)    
+    
+def tick_and_add_block(spec, store, signed_block, test_steps, valid=True,
+                       merge_block=False, block_not_found=False, is_optimistic=False):
+    pre_state = store.block_states[signed_block.message.parent_root]
+    if merge_block:
+        assert spec.is_merge_transition_block(pre_state, signed_block.message.body)
+
+    block_time = pre_state.genesis_time + signed_block.message.slot * spec.config.SECONDS_PER_SLOT
+    while store.time < block_time:
+        time = pre_state.genesis_time + (spec.get_current_slot(store) + 1) * spec.config.SECONDS_PER_SLOT
+        on_tick_step(spec, store, time, test_steps)
+
+    post_state = yield from add_block(
+        spec, store, signed_block, test_steps,
+        valid=valid,
+        block_not_found=block_not_found,
+        is_optimistic=is_optimistic,
+    )
+
+    return post_state
+    
+def apply_next_epoch_with_attestations(spec,
+                                       state,
+                                       store,
+                                       fill_cur_epoch,
+                                       fill_prev_epoch,
+                                       participation_fn=None,
+                                       test_steps=None):
+    if test_steps is None:
+        test_steps = []
+
+    _, new_signed_blocks, post_state = next_epoch_with_attestations(
+        spec, state, fill_cur_epoch, fill_prev_epoch, participation_fn=participation_fn)
+    for signed_block in new_signed_blocks:
+        block = signed_block.message
+        yield from tick_and_add_block(spec, store, signed_block, test_steps, is_optimistic=True)
+        block_root = block.hash_tree_root()
+        assert store.blocks[block_root] == block
+        last_signed_block = signed_block
+
+    assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
+
+    return post_state, store, last_signed_block  
+
+def apply_next_slots_with_attestations(spec,
+                                       state,
+                                       store,
+                                       slots,
+                                       fill_cur_epoch,
+                                       fill_prev_epoch,
+                                       test_steps,
+                                       participation_fn=None):
+    _, new_signed_blocks, post_state = next_slots_with_attestations(
+        spec, state, slots, fill_cur_epoch, fill_prev_epoch, participation_fn=participation_fn)
+    for signed_block in new_signed_blocks:
+        block = signed_block.message
+        yield from tick_and_add_block(spec, store, signed_block, test_steps, is_optimistic=True)
+        block_root = block.hash_tree_root()
+        assert store.blocks[block_root] == block
+        last_signed_block = signed_block
+
+    assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
+
+    return post_state, store, last_signed_block  
+
+
+def get_ancestor(
+    store,
+    root,
+    ancestor_number
+):
+    if ancestor_number == 0:
+        return root
+    else:
+        return get_ancestor(store, store.blocks[root].parent_root, ancestor_number-1)
+    
+def get_block_root_from_head(
+    spec,
+    store,
+    depth
+):
+    head_root = spec.get_head(store)
+    return get_ancestor(store, head_root, depth)
+        
+def get_valid_attestation_for_block(
+    spec,
+    store,
+    block_root,
+    perc
+):
+    """
+    Get attestation filled by `perc`%
+    """
+    return list(
+        get_valid_attestation_at_slot(store.block_states[block_root], 
+                                      spec, spec.get_slots_since_genesis(store), 
+                                      lambda slot, index, comm: set(list(comm)[0:int(len(comm)*perc)]))
+        )    
+
+def confirmation_rule_setup(confirmation_byzantine_threshold: int, confirmation_slashing_threshold: int):        
+    def decorator(func):
+        def wrapped(*args, **kwargs):
+            def check_is_confirmed(
+                spec,
+                store,
+                block_root,
+                test_steps,
+                expected=None
+            ):
+                confirmed = spec.is_confirmed(store, confirmation_byzantine_threshold, confirmation_slashing_threshold, block_root)
+                if expected != None:
+                    assert confirmed == expected
+                test_steps.append({
+                    'check_is_confirmed': {
+                        'result': confirmed,
+                        'block_root': str(block_root)
+                    }
+                }) 
+                
+            def is_lmd_confirmed(
+                spec,
+                store,
+                block_root,
+            ):
+                return spec.is_lmd_confirmed(store, confirmation_byzantine_threshold, block_root)         
+            
+            def is_ffg_confirmed(
+                spec,
+                store,
+                block_root,
+            ):
+                return spec.is_ffg_confirmed(store, confirmation_byzantine_threshold, confirmation_slashing_threshold, block_root)                   
+                                              
+            def check_get_confirmation_score(
+                spec,
+                store,
+                block_root,
+                test_steps,
+                expected=None
+            ):
+                confirmation_score = int(spec.get_confirmation_score(store, confirmation_slashing_threshold, block_root))
+                if expected != None:
+                    assert confirmation_score == expected
+                test_steps.append({
+                    'check_get_confirmation_score': {
+                        'result': confirmation_score,
+                        'block_root': str(block_root)
+                    }
+                })     
+                
+            def get_confirmation_score(
+                spec,
+                store,
+                block_root
+            ):
+                return spec.get_confirmation_score(store, confirmation_slashing_threshold, block_root)
+            
+            def get_lmd_confirmation_score(
+                spec,
+                store,
+                block_root
+            ):
+                return spec.get_lmd_confirmation_score(store, confirmation_slashing_threshold, block_root)     
+            
+            def get_ffg_confirmation_score(
+                spec,
+                store,
+                block_root
+            ):
+                return spec.get_lmd_confirmation_score(store, confirmation_slashing_threshold, block_root)                                        
+                         
+            yield 'setup', {
+                    'confirmation_byzantine_threshold': confirmation_byzantine_threshold,
+                    'confirmation_slashing_threshold': confirmation_slashing_threshold
+                }
+            yield from func(
+                    *args, 
+                    check_is_confirmed=check_is_confirmed, 
+                    check_get_confirmation_score=check_get_confirmation_score,
+                    is_lmd_confirmed=is_lmd_confirmed,
+                    is_ffg_confirmed=is_ffg_confirmed,
+                    get_confirmation_score=get_confirmation_score,
+                    get_lmd_confirmation_score=get_lmd_confirmation_score,
+                    get_ffg_confirmation_score=get_ffg_confirmation_score,
+                    **kwargs
+                )
+        return wrapped
+    return decorator
+
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=0)
+def test_confirm_current_epoch_no_byz(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    # Fill epoch 1 to 2
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 2 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+    
+    check_is_confirmed(spec, store, root, test_steps, True)
+    
+    yield 'steps', test_steps
+
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=0)
+def test_confirm_previous_epoch_no_byz(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    # Fill epoch 1 to 3
+    for _ in range(3):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) + 1 == spec.get_current_store_epoch(store)
+    
+    check_is_confirmed(spec, store, root, test_steps, True)
+    
+    yield 'steps', test_steps
+
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=0)
+def test_no_confirm_current_epoch_due_to_justified_checkpoint(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    # Fill epoch 1 to 2
+    for _ in range(1):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 2 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+    
+    assert is_lmd_confirmed(spec, store, root)
+    assert is_ffg_confirmed(spec, store, root)
+    
+    check_is_confirmed(spec, store, root, test_steps, False)
+    check_get_confirmation_score(spec, store, root, test_steps, -1)
+    
+    yield 'steps', test_steps
+    
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=0)
+def test_no_confirm_previous_epoch_due_to_justified_checkpoint(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) + 1 == spec.get_current_store_epoch(store)
+    
+    assert is_lmd_confirmed(spec, store, root)
+    assert is_ffg_confirmed(spec, store, root)    
+    check_is_confirmed(spec, store, root, test_steps, False)
+    check_get_confirmation_score(spec, store, root, test_steps, -1)
+    
+    yield 'steps', test_steps
+    
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=30, confirmation_slashing_threshold=0)
+def test_no_confirm_current_epoch_but_ffg_confirmed(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 2 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+    
+    assert is_ffg_confirmed(spec, store, root)  
+    block_state = store.block_states[root]
+    assert block_state.current_justified_checkpoint.epoch + 1 == spec.get_current_store_epoch(store)  
+    check_is_confirmed(spec, store, root, test_steps, False)
+    assert get_confirmation_score(spec, store, root) < 30
+    
+    yield 'steps', test_steps
+    
+@with_all_phases
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=30, confirmation_slashing_threshold=0)
+def test_no_confirm_previous_epoch_but_ffg_confirmed(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    # Fill epoch 1 to 3
+    for _ in range(3):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 1)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) + 1 == spec.get_current_store_epoch(store)
+    
+    assert is_ffg_confirmed(spec, store, root)  
+    block_state = store.block_states[root]
+    assert block_state.current_justified_checkpoint.epoch + 2 == spec.get_current_store_epoch(store)      
+    check_is_confirmed(spec, store, root, test_steps, False)
+    assert get_confirmation_score(spec, store, root) < 30
+    
+    yield 'steps', test_steps
+    
+@with_all_phases
+@with_presets([MINIMAL])
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=15, confirmation_slashing_threshold=2048000000000)
+def test_no_confirm_current_epoch_but_lmd_confirmed(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 3 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 2)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+    
+    assert is_lmd_confirmed(spec, store, root)  
+    block_state = store.block_states[root]
+    assert block_state.current_justified_checkpoint.epoch + 1 == spec.get_current_store_epoch(store)  
+
+    check_is_confirmed(spec, store, root, test_steps, False)
+    assert get_confirmation_score(spec, store, root) < 15
+    
+    yield 'steps', test_steps
+    
+# @with_all_phases
+# @with_presets([MINIMAL])
+# @spec_state_test
+# @confirmation_rule_setup(confirmation_byzantine_threshold=15, confirmation_slashing_threshold=2048000000000)
+# def test_no_confirm_previous_epoch_but_lmd_confirmed(
+#     spec, 
+#     state, 
+#     check_is_confirmed, 
+#     check_get_confirmation_score,
+#     is_lmd_confirmed,
+#     is_ffg_confirmed
+# ):
+#     assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+#     test_steps = []
+#     # Initialization
+#     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+#     yield 'anchor_state', state
+#     yield 'anchor_block', anchor_block
+#     current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+#     on_tick_step(spec, store, current_time, test_steps)
+#     assert store.time == current_time
+
+#     next_epoch(spec, state)
+#     on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+#     # Fill epoch 1 to 3
+#     for _ in range(3):
+#         state, store, _ = yield from apply_next_epoch_with_attestations(
+#             spec, state, store, True, True, test_steps=test_steps)
+    
+#     root = get_block_root_from_head(spec, store, 1)
+#     block = store.block_states[root]
+    
+#     assert spec.compute_epoch_at_slot(block.slot) + 1 == spec.get_current_store_epoch(store)
+    
+#     # assert is_lmd_confirmed(spec, store, root)  
+#     block_state = store.block_states[root]
+#     assert block_state.current_justified_checkpoint.epoch + 2 == spec.get_current_store_epoch(store)  
+#     print(spec.get_confirmation_score(store, 2048000000000, root))    
+#     print(spec.get_lmd_confirmation_score(store, root))    
+#     print(spec.get_ffg_confirmation_score(store, 2048000000000, root))    
+#     # check_is_confirmed(spec, store, root, test_steps, False)
+    
+#     yield 'steps', test_steps
+
+
+@with_all_phases
+@with_presets([MINIMAL])
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=0)
+def test_current_get_confirmation_score_no_slashing_threshold(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 3 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 2)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+     
+    check_get_confirmation_score(spec, store, root, test_steps, 23)
+    
+    yield 'steps', test_steps
+    
+@with_all_phases
+@with_presets([MINIMAL])
+@spec_state_test
+@confirmation_rule_setup(confirmation_byzantine_threshold=0, confirmation_slashing_threshold=2048000000000)
+def test_current_get_confirmation_score_slashing_threshold(
+    spec, 
+    state, 
+    check_is_confirmed, 
+    check_get_confirmation_score,
+    is_lmd_confirmed,
+    is_ffg_confirmed,
+    get_confirmation_score,
+    get_lmd_confirmation_score,
+    get_ffg_confirmation_score
+):
+    assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
+        
+    test_steps = []
+    # Initialization
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    next_epoch(spec, state)
+    on_tick_step(spec, store, store.genesis_time + state.slot * spec.config.SECONDS_PER_SLOT, test_steps)
+
+    for _ in range(2):
+        state, store, _ = yield from apply_next_epoch_with_attestations(
+            spec, state, store, True, True, test_steps=test_steps)
+        
+    state, store, _ = yield from apply_next_slots_with_attestations(spec, state, store, 3 , True, True, test_steps=test_steps)
+    
+    root = get_block_root_from_head(spec, store, 2)
+    block = store.block_states[root]
+    
+    assert spec.compute_epoch_at_slot(block.slot) == spec.get_current_store_epoch(store)
+    
+    check_get_confirmation_score(spec, store, root, test_steps, 13)
+    
+    yield 'steps', test_steps
+    

--- a/tests/formats/confirmation_rule/README.md
+++ b/tests/formats/confirmation_rule/README.md
@@ -1,0 +1,115 @@
+# Confirmation tests
+
+The aim of the confirmation rule tests is to provide test coverage of the various components of the confirmation rule.
+
+## Test case format
+
+### `meta.yaml`
+
+```yaml
+description: string    -- Optional. Description of test case, purely for debugging purposes.
+bls_setting: int       -- see general test-format spec.
+```
+
+### `anchor_state.ssz_snappy`
+
+An SSZ-snappy encoded `BeaconState`, the state to initialize store with `get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock)` helper.
+
+### `anchor_block.ssz_snappy`
+
+An SSZ-snappy encoded `BeaconBlock`, the block to initialize store with `get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock)` helper.
+
+### `setup.yaml`
+
+The setup parameters for the confirmation rule algorithm
+
+```yaml
+{
+    confirmation_byzantine_threshold: int,
+    confirmation_slashing_threshold: int
+}
+```
+
+### `steps.yaml`
+
+The steps to execute in sequence. There may be multiple items of the following types:
+
+#### `on_tick` execution step
+
+The parameter that is required for executing `on_tick(store, time)`.
+
+```yaml
+{
+    tick: int       -- to execute `on_tick(store, time)`.
+}
+```
+
+After this step, the `store` object may have been updated.
+
+#### `on_attestation` execution step
+
+The parameter that is required for executing `on_attestation(store, attestation)`.
+
+```yaml
+{
+    attestation: string  -- the name of the `attestation_<32-byte-root>.ssz_snappy` file.
+                            To execute `on_attestation(store, attestation)` with the given attestation.
+}
+```
+The file is located in the same folder (see below).
+
+After this step, the `store` object may have been updated.
+
+#### `on_block` execution step
+
+The parameter that is required for executing `on_block(store, block)`.
+
+```yaml
+{
+    block: string  -- the name of the `block_<32-byte-root>.ssz_snappy` file.
+                      To execute `on_block(store, block)` with the given attestation.
+}  
+```
+The file is located in the same folder (see below).
+
+After this step, the `store` object may have been updated.
+
+#### `on_attester_slashing` execution step
+
+The parameter that is required for executing `on_attester_slashing(store, attester_slashing)`.
+
+```yaml
+{
+    attester_slashing: string  -- the name of the `attester_slashing_<32-byte-root>.ssz_snappy` file.
+                            To execute `on_attester_slashing(store, attester_slashing)` with the given attester slashing.
+}
+```
+The file is located in the same folder (see below).
+
+After this step, the `store` object may have been updated.
+
+#### Checks step
+
+The checks to verify the execution of the confirmation rule algorithm
+
+```yaml
+    check_is_confirmed: {
+        result: bool,          -- return value of is_confirmed using the setup parameters
+        block_root: string     -- block to execute is_confirmed ont
+    }
+```
+
+```yaml
+    check_get_confirmation_score: {
+        result: bool,          -- return value of get_confirmation_score using setup parameters
+        block_root: string     -- block to execute get_confirmation_score on
+    }
+```
+
+## Condition
+
+1. Deserialize `anchor_state.ssz_snappy` and `anchor_block.ssz_snappy` to initialize the local store object by with `get_forkchoice_store(anchor_state, anchor_block)` helper.
+2. Iterate sequentially through `steps.yaml`
+    - For each execution, look up the corresponding ssz_snappy file. Execute the corresponding helper function on the current store.
+        - For the `on_block` execution step: if `len(block.message.body.attestations) > 0`, execute each attestation with `on_attestation(store, attestation)` after executing `on_block(store, block)`.
+    - For each `checks` step, the assertions on the values returned by the confirmation rule algorithm must be satisfied.

--- a/tests/generators/confirmation_rule/README.md
+++ b/tests/generators/confirmation_rule/README.md
@@ -1,0 +1,5 @@
+# Confirmation rule tests
+
+The confirmation rule tests cover the confirmation rule implementations
+
+Information on the format of the tests can be found in the [confirmation rule test formats documentation](../../formats/confirmation_rule/README.md).

--- a/tests/generators/confirmation_rule/main.py
+++ b/tests/generators/confirmation_rule/main.py
@@ -1,0 +1,22 @@
+from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
+from eth2spec.test.helpers.constants import BELLATRIX, CAPELLA, DENEB, EIP6110
+
+
+if __name__ == "__main__":
+    # Note: Confirmation rule tests start from Bellatrix
+    bellatrix_mods = {key: 'eth2spec.test.bellatrix.confirmation_rule.test_' + key for key in [
+        'confirmation_rule'
+    ]}
+
+    capella_mods = bellatrix_mods  # No additional Capella specific fork choice tests
+    deneb_mods = capella_mods  # No additional Deneb specific fork choice tests
+    eip6110_mods = deneb_mods  # No additional EIP6110 specific fork choice tests
+
+    all_mods = {
+        BELLATRIX: bellatrix_mods,
+        CAPELLA: capella_mods,
+        DENEB: deneb_mods,
+        EIP6110: eip6110_mods,
+    }
+
+    run_state_test_generators(runner_name="confirmation_rule", all_mods=all_mods)

--- a/tests/generators/confirmation_rule/requirements.txt
+++ b/tests/generators/confirmation_rule/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=4.4
+../../../[generator]


### PR DESCRIPTION
### TODO

- [x] Extend confirmation rule to get_confirmation_score